### PR TITLE
Use cuda-cccl_{{ target_platform }}.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   run:
     - cuda-cudart-dev 12.6.37
-    - cuda-cccl 12.6.37
+    - cuda-cccl_{{ target_platform }} 12.6.37
     - cuda-profiler-api 12.6.37
     - cuda-driver-dev 12.6.37    # [linux]
     - cuda-nvrtc-dev 12.6.20


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

From discussion with @cwharris and @robertmaynard, it seems like `cuda-libraries-dev` should depend on `cuda-cccl_{{ target_platform }}` rather than `cuda-cccl`. For the use cases in CUDA libraries, the CCCL headers should be in the `$PREFIX/targets/.../include` directory (as in `cuda-cccl_{{ target_platform }}`) rather than `$PREFIX/include` (as in `cuda-cccl`, the metapackage that selects `cccl` for a given CUDA version). This caused an issue observed while building with `cuda-libraries-dev` and a dependency that fetched CCCL via CPM.
